### PR TITLE
Use radio buttons for existing user accounts

### DIFF
--- a/app/assets/javascripts/spree/frontend/gestpay/iframe.js.coffee
+++ b/app/assets/javascripts/spree/frontend/gestpay/iframe.js.coffee
@@ -16,7 +16,11 @@ class form
     $('#js-gestpay-form').trigger('submit')
 
   get: (id) ->
-    $("##{id}").val()
+    element = $("##{id}")
+    if id == 'account' && element.is('fieldset')
+      element = element.find("input[name=#{id}]:checked")
+
+    element.val()
 
 class iframe extends SpreeGestpay.module
   constructor: (@merchant, @tokenPath, @transaction, @amount) ->
@@ -33,8 +37,7 @@ class iframe extends SpreeGestpay.module
     @profileSelect.is('*')
 
   setCreditCardFields: =>
-    selectedProfile = @profileSelect.find(':selected')
-
+    selectedProfile = @profileSelect.find(':selected, :checked')
     if !@hasProfiles() or selectedProfile.data('new-card')
       $('.js-hide-with-profile').show()
     else


### PR DESCRIPTION
This PR aims to allow using radio buttons instead of a select when choosing existing credit card profiles. 